### PR TITLE
samples: add chained on-prem routing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ A runnable sample is available under `samples/Aggregation`:
 
 - `Sample.Aggregate.Cloud`: cloud endpoint (`MapTunnelHost`) for incoming on-prem tunnel connections.
 - `Sample.Aggregate.Client`: on-prem app that opens the tunnel to cloud.
-- `Sample.Aggregate.OnPrem`: on-prem gateway that exposes both `/gateway` (own UI/API) and `/internal/*` routes.
+- `Sample.Aggregate.OnPrem`: on-prem gateway that exposes `/gateway` (own UI/API) and uses YARP reverse proxy for `/internal/*` with a `/internal` path-prefix removal transform.
 - `Sample.Aggregate.InternalApp`: downstream on-prem app reachable from the gateway over local network.
 
 Run all four samples and call:

--- a/README.md
+++ b/README.md
@@ -424,6 +424,12 @@ Run all four samples and call:
 - `https://localhost:7400/client` -> forwarded over tunnel to `Sample.Aggregate.Client`.
 - `https://localhost:7400/internal` -> forwarded over tunnel to gateway, then proxied to `Sample.Aggregate.InternalApp`.
 
+For a runtime-configurable UI sample, see `samples/Sample.Blazor`:
+
+- Open `/gateway-routes` to manage route entries in-memory (add/edit/delete).
+- A default route maps `/gateway/internal/*` to `http://localhost:5600/*` and strips `/internal` before forwarding.
+- You can configure path-prefix behavior (`StripPrefix` on/off), destination base URL, and enable/disable routes at runtime.
+
 ### Chained proxy guidance for third-party apps (no app changes possible)
 
 When the downstream app is third-party and cannot be modified, path/base-url issues are the most common source of broken CSS/JS, redirects, and login flows.

--- a/UFX.Relay.sln
+++ b/UFX.Relay.sln
@@ -40,6 +40,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.Aggregate.Cloud", "s
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.Aggregate.Client", "samples\Aggregation\Sample.Aggregate.Client\Sample.Aggregate.Client.csproj", "{2126A733-7CE3-407C-9552-6B47D50EA904}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.Aggregate.InternalApp", "samples\Aggregation\Sample.Aggregate.InternalApp\Sample.Aggregate.InternalApp.csproj", "{D777DD87-522B-4FCD-A50C-26C03D82B969}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -82,6 +84,10 @@ Global
 		{2126A733-7CE3-407C-9552-6B47D50EA904}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2126A733-7CE3-407C-9552-6B47D50EA904}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2126A733-7CE3-407C-9552-6B47D50EA904}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D777DD87-522B-4FCD-A50C-26C03D82B969}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D777DD87-522B-4FCD-A50C-26C03D82B969}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D777DD87-522B-4FCD-A50C-26C03D82B969}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D777DD87-522B-4FCD-A50C-26C03D82B969}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -97,6 +103,7 @@ Global
 		{342EBDB3-6D92-4EB8-8401-E4E4D287BF9D} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{AA0B38F1-8F8E-9B50-97C1-08B5E5B47018} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{2126A733-7CE3-407C-9552-6B47D50EA904} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{D777DD87-522B-4FCD-A50C-26C03D82B969} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {04FED86F-BEE8-4214-B9BE-14BAD57013AE}

--- a/samples/Aggregation/Sample.Aggregate.InternalApp/Program.cs
+++ b/samples/Aggregation/Sample.Aggregate.InternalApp/Program.cs
@@ -1,7 +1,121 @@
+using System.Diagnostics;
+using System.Text;
+using Microsoft.AspNetCore.HttpLogging;
+
 var builder = WebApplication.CreateBuilder(args);
+
+// --- Logging (Console) ---
+builder.Logging.ClearProviders();
+builder.Logging.AddSimpleConsole(o =>
+{
+    o.SingleLine = true;
+    o.TimestampFormat = "HH:mm:ss.fff ";
+});
+
+// --- HTTP request/response logging (built-in) ---
+builder.Services.AddHttpLogging(o =>
+{
+    o.LoggingFields =
+        HttpLoggingFields.RequestPropertiesAndHeaders |
+        HttpLoggingFields.RequestBody |
+        HttpLoggingFields.ResponsePropertiesAndHeaders |
+        HttpLoggingFields.ResponseBody;
+
+    o.RequestBodyLogLimit = 64 * 1024;
+    o.ResponseBodyLogLimit = 64 * 1024;
+
+    // Optional: avoid logging very noisy headers
+    // o.RequestHeaders.Remove("Authorization");
+    // o.ResponseHeaders.Remove("Set-Cookie");
+});
+
 var app = builder.Build();
 
-app.MapGet("/", () => "Hello from downstream on-prem app");
-app.MapGet("/status", () => Results.Ok(new { name = "downstream-onprem", status = "ok" }));
+app.UseHttpLogging();
+
+// --- Extra middleware: timing + correlation + exception logging ---
+app.Use(async (ctx, next) =>
+{
+    var log = ctx.RequestServices.GetRequiredService<ILoggerFactory>().CreateLogger("RequestTrace");
+
+    var id = ctx.TraceIdentifier;
+    ctx.Response.Headers["x-trace-id"] = id;
+
+    var sw = Stopwatch.StartNew();
+    log.LogInformation("BEGIN {Method} {Path}{Query} from {RemoteIp}",
+        ctx.Request.Method,
+        ctx.Request.Path,
+        ctx.Request.QueryString,
+        ctx.Connection.RemoteIpAddress);
+
+    try
+    {
+        await next();
+        sw.Stop();
+
+        log.LogInformation("END   {Method} {Path} -> {StatusCode} in {ElapsedMs}ms",
+            ctx.Request.Method,
+            ctx.Request.Path,
+            ctx.Response.StatusCode,
+            sw.ElapsedMilliseconds);
+    }
+    catch (Exception ex)
+    {
+        sw.Stop();
+        log.LogError(ex, "FAIL  {Method} {Path} after {ElapsedMs}ms",
+            ctx.Request.Method,
+            ctx.Request.Path,
+            sw.ElapsedMilliseconds);
+        throw;
+    }
+});
+
+// --- Endpoints ---
+app.MapGet("/", (HttpContext ctx, ILoggerFactory lf) =>
+{
+    lf.CreateLogger("Downstream").LogInformation("Handler: GET / (TraceId={TraceId})", ctx.TraceIdentifier);
+    return "Hello from downstream on-prem app";
+});
+
+app.MapGet("/status", (HttpContext ctx, ILoggerFactory lf) =>
+{
+    lf.CreateLogger("Downstream").LogInformation("Handler: GET /status (TraceId={TraceId})", ctx.TraceIdentifier);
+    return Results.Ok(new { name = "downstream-onprem", status = "ok", traceId = ctx.TraceIdentifier });
+});
+
+// --- Catch-all for seeing paths/headers/body easily ---
+app.Map("/{**catchAll}", async (HttpContext ctx, ILoggerFactory lf) =>
+{
+    var log = lf.CreateLogger("Downstream.CatchAll");
+
+    string body = "";
+    if (ctx.Request.ContentLength is > 0)
+    {
+        ctx.Request.EnableBuffering();
+        using var reader = new StreamReader(ctx.Request.Body, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, leaveOpen: true);
+        body = await reader.ReadToEndAsync();
+        ctx.Request.Body.Position = 0;
+    }
+
+    log.LogWarning("CatchAll hit: {Method} {Path}{Query} ContentType={ContentType} BodyLen={BodyLen}",
+        ctx.Request.Method,
+        ctx.Request.Path,
+        ctx.Request.QueryString,
+        ctx.Request.ContentType,
+        body.Length);
+
+    // Echo back useful debug info
+    return Results.Json(new
+    {
+        message = "CatchAll (debug)",
+        method = ctx.Request.Method,
+        path = ctx.Request.Path.Value,
+        query = ctx.Request.QueryString.Value,
+        traceId = ctx.TraceIdentifier,
+        remoteIp = ctx.Connection.RemoteIpAddress?.ToString(),
+        headers = ctx.Request.Headers.ToDictionary(k => k.Key, v => v.Value.ToString()),
+        body
+    });
+});
 
 await app.RunAsync();

--- a/samples/Aggregation/Sample.Aggregate.InternalApp/Program.cs
+++ b/samples/Aggregation/Sample.Aggregate.InternalApp/Program.cs
@@ -1,0 +1,7 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello from downstream on-prem app");
+app.MapGet("/status", () => Results.Ok(new { name = "downstream-onprem", status = "ok" }));
+
+await app.RunAsync();

--- a/samples/Aggregation/Sample.Aggregate.InternalApp/Properties/launchSettings.json
+++ b/samples/Aggregation/Sample.Aggregate.InternalApp/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5600",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7600;http://localhost:5600",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/Aggregation/Sample.Aggregate.InternalApp/Sample.Aggregate.InternalApp.csproj
+++ b/samples/Aggregation/Sample.Aggregate.InternalApp/Sample.Aggregate.InternalApp.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/samples/Aggregation/Sample.Aggregate.InternalApp/appsettings.Development.json
+++ b/samples/Aggregation/Sample.Aggregate.InternalApp/appsettings.Development.json
@@ -4,9 +4,5 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  },
-  "DownstreamApp": {
-    "BaseUrl": "http://localhost:5600"
-  },
-  "AllowedHosts": "*"
+  }
 }

--- a/samples/Aggregation/Sample.Aggregate.InternalApp/appsettings.json
+++ b/samples/Aggregation/Sample.Aggregate.InternalApp/appsettings.json
@@ -5,8 +5,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "DownstreamApp": {
-    "BaseUrl": "http://localhost:5600"
-  },
   "AllowedHosts": "*"
 }

--- a/samples/Aggregation/Sample.Aggregate.OnPrem/Program.cs
+++ b/samples/Aggregation/Sample.Aggregate.OnPrem/Program.cs
@@ -1,8 +1,6 @@
-﻿
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using UFX.Relay.Tunnel;
 using UFX.Relay.Tunnel.Forwarder;
-using UFX.Relay.Tunnel.Listener;
 
 Console.WriteLine(@"
 
@@ -18,16 +16,37 @@ Console.WriteLine(@"
 ");
 
 var builder = WebApplication.CreateBuilder(args);
-builder.Services.AddAggregatedTunnelForwarder(options => 
+
+builder.Services.AddAggregatedTunnelForwarder(options =>
 {
-    options.DefaultTunnelId = "123"; 
+    options.DefaultTunnelId = "123";
 });
+
 builder.Services.AddTunnelClient(options =>
-    options with 
+    options with
     {
-       TunnelHost = "wss://localhost:7400",
-       TunnelId = "on-prem-aggregator",
-});
+        TunnelHost = "wss://localhost:7400",
+        TunnelId = "on-prem-aggregator",
+    });
+
+var downstreamAppBaseUrl = builder.Configuration["DownstreamApp:BaseUrl"] ?? "http://localhost:5600";
+builder.Services.AddHttpClient("downstream-app", client => client.BaseAddress = new Uri(downstreamAppBaseUrl));
+
 var app = builder.Build();
+
+app.MapGet("/gateway", () => "Hello from On-Prem gateway app");
+
+app.MapGet("/internal", async (IHttpClientFactory httpClientFactory) =>
+{
+    var httpClient = httpClientFactory.CreateClient("downstream-app");
+    return await httpClient.GetStringAsync("/");
+});
+
+app.MapGet("/internal/{**path}", async (string? path, IHttpClientFactory httpClientFactory) =>
+{
+    var httpClient = httpClientFactory.CreateClient("downstream-app");
+    return await httpClient.GetStringAsync(path ?? string.Empty);
+});
+
 app.MapTunnelForwarder();
 await app.RunAsync();

--- a/samples/Aggregation/Sample.Aggregate.OnPrem/Sample.Aggregate.OnPrem.csproj
+++ b/samples/Aggregation/Sample.Aggregate.OnPrem/Sample.Aggregate.OnPrem.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Yarp.ReverseProxy" Version="2.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\src\UFX.Relay\UFX.Relay.csproj" />
   </ItemGroup>
 

--- a/samples/Sample.Blazor/Components/Layout/NavMenu.razor
+++ b/samples/Sample.Blazor/Components/Layout/NavMenu.razor
@@ -31,6 +31,12 @@
                 <span class="bi bi-arrow-down-up-nav-menu" aria-hidden="true"></span> Tunnel Setup
             </NavLink>
         </div>
+
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="gateway-routes">
+                <span class="bi bi-router-fill-nav-menu" aria-hidden="true"></span> Gateway Routes
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/samples/Sample.Blazor/Components/Pages/GatewayRoutes.razor
+++ b/samples/Sample.Blazor/Components/Pages/GatewayRoutes.razor
@@ -1,0 +1,148 @@
+@page "/gateway-routes"
+@using Sample.Blazor.Gateway
+@inject GatewayRouteStore RouteStore
+
+<h3>Gateway Routes (runtime)</h3>
+<p>
+    Configure path-prefix routes for the on-prem gateway proxy endpoint <code>/gateway/*</code>.
+</p>
+
+<div class="card mb-4">
+    <div class="card-header">@(isEditMode ? "Edit Route" : "Add Route")</div>
+    <div class="card-body">
+        <div class="mb-3">
+            <label class="form-label">Name</label>
+            <input class="form-control" @bind="form.Name" />
+        </div>
+
+        <div class="mb-3">
+            <label class="form-label">Path Prefix</label>
+            <input class="form-control" @bind="form.PathPrefix" placeholder="/internal" />
+            <div class="form-text">Matched under <code>/gateway</code>. Example: <code>/internal</code>.</div>
+        </div>
+
+        <div class="mb-3">
+            <label class="form-label">Destination Base URL</label>
+            <input class="form-control" @bind="form.DestinationBaseUrl" placeholder="http://localhost:5600/" />
+        </div>
+
+        <div class="form-check mb-2">
+            <input id="stripPrefix" class="form-check-input" type="checkbox" @bind="form.StripPrefix" />
+            <label class="form-check-label" for="stripPrefix">Strip prefix before proxying (YARP-style PathRemovePrefix)</label>
+        </div>
+
+        <div class="form-check mb-3">
+            <input id="isEnabled" class="form-check-input" type="checkbox" @bind="form.IsEnabled" />
+            <label class="form-check-label" for="isEnabled">Enabled</label>
+        </div>
+
+        <button class="btn btn-primary me-2" @onclick="Save">@(isEditMode ? "Update" : "Add")</button>
+        @if (isEditMode)
+        {
+            <button class="btn btn-secondary" @onclick="ResetForm">Cancel</button>
+        }
+    </div>
+</div>
+
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Prefix</th>
+            <th>Destination</th>
+            <th>Mode</th>
+            <th>Status</th>
+            <th>Sample URL</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var route in routes)
+        {
+            <tr>
+                <td>@route.Name</td>
+                <td><code>@route.PathPrefix</code></td>
+                <td><code>@route.DestinationBaseUrl</code></td>
+                <td>@(route.StripPrefix ? "StripPrefix" : "KeepPrefix")</td>
+                <td>@(route.IsEnabled ? "Enabled" : "Disabled")</td>
+                <td><code>/gateway@route.PathPrefix</code></td>
+                <td>
+                    <button class="btn btn-sm btn-outline-primary me-2" @onclick="() => Edit(route)">Edit</button>
+                    <button class="btn btn-sm btn-outline-danger" @onclick="() => Delete(route.Id)">Delete</button>
+                </td>
+            </tr>
+        }
+    </tbody>
+</table>
+
+@code {
+    private List<GatewayRoute> routes = [];
+    private GatewayRouteForm form = GatewayRouteForm.New();
+    private bool isEditMode;
+
+    protected override void OnInitialized()
+    {
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        routes = RouteStore.GetAll().OrderBy(x => x.PathPrefix).ThenBy(x => x.Name).ToList();
+    }
+
+    private void Save()
+    {
+        var route = new GatewayRoute
+        {
+            Id = form.Id ?? Guid.NewGuid(),
+            Name = string.IsNullOrWhiteSpace(form.Name) ? "Route" : form.Name.Trim(),
+            PathPrefix = string.IsNullOrWhiteSpace(form.PathPrefix) ? "/" : form.PathPrefix.Trim(),
+            DestinationBaseUrl = string.IsNullOrWhiteSpace(form.DestinationBaseUrl) ? "http://localhost:5600/" : form.DestinationBaseUrl.Trim(),
+            StripPrefix = form.StripPrefix,
+            IsEnabled = form.IsEnabled
+        };
+
+        RouteStore.Upsert(route);
+        ResetForm();
+        Refresh();
+    }
+
+    private void Edit(GatewayRoute route)
+    {
+        isEditMode = true;
+        form = new GatewayRouteForm
+        {
+            Id = route.Id,
+            Name = route.Name,
+            PathPrefix = route.PathPrefix,
+            DestinationBaseUrl = route.DestinationBaseUrl,
+            StripPrefix = route.StripPrefix,
+            IsEnabled = route.IsEnabled
+        };
+    }
+
+    private void Delete(Guid id)
+    {
+        RouteStore.Delete(id);
+        ResetForm();
+        Refresh();
+    }
+
+    private void ResetForm()
+    {
+        isEditMode = false;
+        form = GatewayRouteForm.New();
+    }
+
+    private sealed class GatewayRouteForm
+    {
+        public Guid? Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string PathPrefix { get; set; } = "/internal";
+        public string DestinationBaseUrl { get; set; } = "http://localhost:5600/";
+        public bool StripPrefix { get; set; } = true;
+        public bool IsEnabled { get; set; } = true;
+
+        public static GatewayRouteForm New() => new();
+    }
+}

--- a/samples/Sample.Blazor/Gateway/GatewayRoute.cs
+++ b/samples/Sample.Blazor/Gateway/GatewayRoute.cs
@@ -1,0 +1,11 @@
+namespace Sample.Blazor.Gateway;
+
+public sealed record GatewayRoute
+{
+    public Guid Id { get; init; } = Guid.NewGuid();
+    public required string Name { get; init; }
+    public required string PathPrefix { get; init; }
+    public required string DestinationBaseUrl { get; init; }
+    public bool StripPrefix { get; init; } = true;
+    public bool IsEnabled { get; init; } = true;
+}

--- a/samples/Sample.Blazor/Gateway/GatewayRouteStore.cs
+++ b/samples/Sample.Blazor/Gateway/GatewayRouteStore.cs
@@ -82,15 +82,16 @@ public sealed class GatewayRouteStore
                 }
 
                 var nextCharIndex = candidate.PathPrefix.Length;
+                var isRootPrefix = candidate.PathPrefix == "/";
                 var isExact = normalizedPath.Length == nextCharIndex;
                 var isSubPath = !isExact && normalizedPath[nextCharIndex] == '/';
-                if (!isExact && !isSubPath)
+                if (!isRootPrefix && !isExact && !isSubPath)
                 {
                     continue;
                 }
 
                 route = candidate;
-                rewrittenPath = candidate.StripPrefix
+                rewrittenPath = candidate.StripPrefix && !isRootPrefix
                     ? NormalizeRequestPath(normalizedPath[nextCharIndex..])
                     : normalizedPath;
                 return true;

--- a/samples/Sample.Blazor/Gateway/GatewayRouteStore.cs
+++ b/samples/Sample.Blazor/Gateway/GatewayRouteStore.cs
@@ -35,7 +35,7 @@ public sealed class GatewayRouteStore
 
         lock (sync)
         {
-            var index = routes.FindIndex(r => r.Id == normalized.Id);
+            var index = FindIndexById(routes, normalized.Id);
             if (index >= 0)
             {
                 routes = routes.SetItem(index, normalized);
@@ -100,6 +100,20 @@ public sealed class GatewayRouteStore
         route = default!;
         rewrittenPath = string.Empty;
         return false;
+    }
+
+
+    private static int FindIndexById(ImmutableArray<GatewayRoute> source, Guid id)
+    {
+        for (var i = 0; i < source.Length; i++)
+        {
+            if (source[i].Id == id)
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     private static string NormalizePrefix(string prefix)

--- a/samples/Sample.Blazor/Gateway/GatewayRouteStore.cs
+++ b/samples/Sample.Blazor/Gateway/GatewayRouteStore.cs
@@ -1,0 +1,143 @@
+using System.Collections.Immutable;
+
+namespace Sample.Blazor.Gateway;
+
+public sealed class GatewayRouteStore
+{
+    private readonly object sync = new();
+    private ImmutableArray<GatewayRoute> routes =
+    [
+        new GatewayRoute
+        {
+            Name = "Sample Internal App",
+            PathPrefix = "/internal",
+            DestinationBaseUrl = "http://localhost:5600/",
+            StripPrefix = true,
+            IsEnabled = true
+        }
+    ];
+
+    public IReadOnlyList<GatewayRoute> GetAll()
+    {
+        lock (sync)
+        {
+            return routes;
+        }
+    }
+
+    public GatewayRoute Upsert(GatewayRoute route)
+    {
+        GatewayRoute normalized = route with
+        {
+            PathPrefix = NormalizePrefix(route.PathPrefix),
+            DestinationBaseUrl = NormalizeDestinationBaseUrl(route.DestinationBaseUrl)
+        };
+
+        lock (sync)
+        {
+            var index = routes.FindIndex(r => r.Id == normalized.Id);
+            if (index >= 0)
+            {
+                routes = routes.SetItem(index, normalized);
+            }
+            else
+            {
+                routes = routes.Add(normalized);
+            }
+        }
+
+        return normalized;
+    }
+
+    public bool Delete(Guid id)
+    {
+        lock (sync)
+        {
+            var existing = routes.FirstOrDefault(r => r.Id == id);
+            if (existing is null)
+            {
+                return false;
+            }
+
+            routes = routes.Remove(existing);
+            return true;
+        }
+    }
+
+    public bool TryMatch(string requestPath, out GatewayRoute route, out string rewrittenPath)
+    {
+        string normalizedPath = NormalizeRequestPath(requestPath);
+
+        lock (sync)
+        {
+            var candidates = routes
+                .Where(r => r.IsEnabled)
+                .OrderByDescending(r => r.PathPrefix.Length);
+
+            foreach (var candidate in candidates)
+            {
+                if (!normalizedPath.StartsWith(candidate.PathPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var nextCharIndex = candidate.PathPrefix.Length;
+                var isExact = normalizedPath.Length == nextCharIndex;
+                var isSubPath = !isExact && normalizedPath[nextCharIndex] == '/';
+                if (!isExact && !isSubPath)
+                {
+                    continue;
+                }
+
+                route = candidate;
+                rewrittenPath = candidate.StripPrefix
+                    ? NormalizeRequestPath(normalizedPath[nextCharIndex..])
+                    : normalizedPath;
+                return true;
+            }
+        }
+
+        route = default!;
+        rewrittenPath = string.Empty;
+        return false;
+    }
+
+    private static string NormalizePrefix(string prefix)
+    {
+        var trimmed = string.IsNullOrWhiteSpace(prefix) ? "/" : prefix.Trim();
+
+        if (!trimmed.StartsWith('/'))
+        {
+            trimmed = '/' + trimmed;
+        }
+
+        if (trimmed.Length > 1)
+        {
+            trimmed = trimmed.TrimEnd('/');
+        }
+
+        return trimmed;
+    }
+
+    private static string NormalizeDestinationBaseUrl(string destinationBaseUrl)
+    {
+        var trimmed = destinationBaseUrl.Trim();
+        if (!trimmed.EndsWith('/'))
+        {
+            trimmed += "/";
+        }
+
+        return trimmed;
+    }
+
+    private static string NormalizeRequestPath(string requestPath)
+    {
+        var normalized = string.IsNullOrWhiteSpace(requestPath) ? "/" : requestPath;
+        if (!normalized.StartsWith('/'))
+        {
+            normalized = '/' + normalized;
+        }
+
+        return normalized;
+    }
+}

--- a/samples/Sample.Blazor/Gateway/PathOverrideTransformer.cs
+++ b/samples/Sample.Blazor/Gateway/PathOverrideTransformer.cs
@@ -1,0 +1,28 @@
+﻿using Yarp.ReverseProxy.Forwarder;
+
+namespace Sample.Blazor.Gateway
+{
+    internal sealed class PathOverrideTransformer : HttpTransformer
+    {
+        private readonly string _path;
+        public PathOverrideTransformer(string path) => _path = path;
+
+        public override async ValueTask TransformRequestAsync(
+            HttpContext httpContext,
+            HttpRequestMessage proxyRequest,
+            string destinationPrefix,
+            CancellationToken cancellationToken)
+        {
+            await base.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix, cancellationToken);
+
+            // Override path+query explicitly (this is the critical part)
+            proxyRequest.RequestUri = RequestUtilities.MakeDestinationAddress(
+                destinationPrefix,
+                _path,
+                httpContext.Request.QueryString);
+
+            // Optional: don't forward original Host header
+            proxyRequest.Headers.Host = null;
+        }
+    }
+}

--- a/samples/Sample.Blazor/Program.cs
+++ b/samples/Sample.Blazor/Program.cs
@@ -120,8 +120,10 @@ namespace Sample.Blazor
 
                     var errorFeature = context.GetForwarderErrorFeature();
                     var errorException = errorFeature?.Exception;
+                    var correlationId = Guid.NewGuid().ToString("N");
+                    Console.Error.WriteLine($"Proxy error (CorrelationId: {correlationId}): {error}. Exception: {errorException}");
                     context.Response.StatusCode = StatusCodes.Status502BadGateway;
-                    await context.Response.WriteAsync($"Proxy error: {error}. {errorException?.Message}");
+                    await context.Response.WriteAsync($"Proxy error. Please contact support with CorrelationId: {correlationId}.");
                 }
                 finally
                 {

--- a/samples/Sample.Blazor/Sample.Blazor.csproj
+++ b/samples/Sample.Blazor/Sample.Blazor.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Yarp.ReverseProxy" Version="2.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\UFX.Relay\UFX.Relay.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
### Motivation

- Provide a runnable sample that demonstrates multi-hop / chained routing (SaaS → on-prem gateway → internal on‑prem app) and address the request to add a concrete sample for the README guidance.

### Description

- Add a new sample project `samples/Aggregation/Sample.Aggregate.InternalApp` that hosts a minimal downstream on‑prem app exposing `/` and `/status`.
- Extend `samples/Aggregation/Sample.Aggregate.OnPrem` to register an `HttpClient` (configurable via `DownstreamApp:BaseUrl`) and to expose `/gateway`, `/internal`, and `/internal/{**path}` endpoints that proxy requests to the downstream app while preserving the existing tunnel forwarder/client configuration.
- Add `DownstreamApp:BaseUrl` to `Sample.Aggregate.OnPrem/appsettings.json` with a default of `http://localhost:5600` and provide launch settings for the new sample.
- Update `README.md` to document the 4‑part sample topology and example URLs, and add the new sample to `UFX.Relay.sln` so it is part of the solution.

### Testing

- Ran repository checks including `git diff --check`, which reported no issues.
- Validated JSON files with `python -m json.tool` for `appsettings.json` and `launchSettings.json`, which succeeded.
- Verified the diffs and presence of added sample files and solution updates via local file/diff inspection.
- The `dotnet` CLI is not available in this environment, so a full `dotnet build` / runtime verification could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69859e7e48dc832495147005da92588e)